### PR TITLE
use the new c"" block style

### DIFF
--- a/docs/source/language-reference/embedded-cpp.rst
+++ b/docs/source/language-reference/embedded-cpp.rst
@@ -26,7 +26,7 @@ example`_.
        a: i32 = 0
        b: i32 = 0
 
-       """mys-embedded-c++
+       c"""
        b = foo::foobar(2);
        a++;
        """

--- a/examples/embedded_cpp/src/main.mys
+++ b/examples/embedded_cpp/src/main.mys
@@ -6,7 +6,7 @@ def main():
     a: i32 = 0
     b: i32 = 0
 
-    """mys-embedded-c++
+    c"""
     b = foo::foobar(2);
     a++;
     """

--- a/examples/wip/poll/src/lib.mys
+++ b/examples/wip/poll/src/lib.mys
@@ -18,7 +18,7 @@ class Poll:
     def __init__(self):
         self._items = {}
 
-        """mys-embedded-c++
+        c"""
         this->_epoll_fd = epoll_create1(0);
         """
 
@@ -31,7 +31,7 @@ class Poll:
 
         """
 
-        """mys-embedded-c++
+        c"""
         struct epoll_event event;
         int res;
 
@@ -60,7 +60,7 @@ class Poll:
 
         """
 
-        """mys-embedded-c++
+        c"""
         struct epoll_event event;
         int res;
 
@@ -94,7 +94,7 @@ class Event(Pollable):
     def __init__(self):
         self._is_set = False
 
-        """mys-embedded-c++
+        c"""
         this->fd = eventfd(0, 0);
         """
 
@@ -164,7 +164,7 @@ class Timer(Pollable):
         self._initial = inital
         self._repeat = repeat
 
-        """mys-embedded-c++
+        c"""
         int fd = timerfd_create(CLOCK_MONOTONIC, 0);
 
         if (fd == -1) {
@@ -177,7 +177,7 @@ class Timer(Pollable):
 
         """
 
-        """mys-embedded-c++
+        c"""
         res = timerfd_settime(this->get_fd(), 0);
 
         if (res == -1) {
@@ -190,7 +190,7 @@ class Timer(Pollable):
 
         """
 
-        """mys-embedded-c++
+        c"""
         res = timerfd_settime(this->get_fd(), 0);
 
         if (res == -1) {

--- a/tests/test_various.py
+++ b/tests/test_various.py
@@ -1083,9 +1083,9 @@ class Test(TestCase):
     def test_embedded_cpp_instead_of_docstring(self):
         source = transpile_source('class Foo:\n'
                                   '    def foo(self):\n'
-                                  '        "mys-embedded-c++ // nothing 1"\n'
+                                  '        c"// nothing 1"\n'
                                   'def bar():\n'
-                                  '    "mys-embedded-c++ // nothing 2"\n')
+                                  '    c"// nothing 2"\n')
 
         self.assert_in('// nothing 1', source)
         self.assert_in('// nothing 2', source)


### PR DESCRIPTION
the new block style c"" that replace mys-embedded-c++ ( but not  "mys-embedded-c++-before-namespace" ) was missing in some places 